### PR TITLE
feat(wizard): implement grid-based progress bar with URL state and animations

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,15 +34,7 @@ export default function Header() {
               alt="TanStack Logo"
               className="h-10"
             /> */}
-            Basic Prompt Builder
-          </Link>
-          <Link to="/prompt-builder/advanced" className="ml-6">
-            {/* <img
-              src="/tanstack-word-logo-white.svg"
-              alt="TanStack Logo"
-              className="h-10"
-            /> */}
-            Advanced Prompt Builder
+            Prompt Wizard
           </Link>
         </h1>
       </header>

--- a/src/components/prompt-wizard/WizardProgress.tsx
+++ b/src/components/prompt-wizard/WizardProgress.tsx
@@ -1,4 +1,4 @@
-import { motion } from "motion/react";
+import { motion, AnimatePresence } from "motion/react";
 import { Check } from "lucide-react";
 import {
   TOTAL_REQUIRED_STEPS,
@@ -36,27 +36,38 @@ export function WizardProgress({
   return (
     <div className="w-full">
       {/* Progress bar */}
-      <div className="flex items-center justify-between mb-4">
-        {steps.map((step, index) => {
-          const stepNumber = index + 1;
-          const isCompleted = completedSteps.has(stepNumber);
-          const isActive = stepNumber === currentStep;
-          const isUpcoming = !isCompleted && !isActive;
+      <motion.div
+        className="grid items-center gap-2 mb-4"
+        style={{
+          gridTemplateColumns: steps
+            .map((_, i) => (i < steps.length - 1 ? "auto 1fr" : "auto"))
+            .join(" "),
+        }}
+        layout
+        transition={{ duration: 0.3, ease: "easeInOut" }}
+      >
+        <AnimatePresence mode="popLayout" initial={false}>
+          {steps.map((step, index) => {
+            const stepNumber = index + 1;
+            const isCompleted = completedSteps.has(stepNumber);
+            const isActive = stepNumber === currentStep;
+            const isUpcoming = !isCompleted && !isActive;
 
-          // Can click if completed or is the next available step
-          const isClickable =
-            stepNumber === 1 ||
-            completedSteps.has(stepNumber) ||
-            completedSteps.has(stepNumber - 1);
+            // Can click if completed or is the next available step
+            const isClickable =
+              stepNumber === 1 ||
+              completedSteps.has(stepNumber) ||
+              completedSteps.has(stepNumber - 1);
 
-          return (
-            <div key={step.id} className="flex items-center flex-1">
-              {/* Step dot */}
-              <motion.button
-                onClick={() => handleStepClick(stepNumber)}
-                disabled={!isClickable}
-                className={`
-                  relative flex items-center justify-center w-10 h-10 
+            return (
+              <>
+                {/* Step dot */}
+                <motion.button
+                  key={`step-${step.id}`}
+                  onClick={() => handleStepClick(stepNumber)}
+                  disabled={!isClickable}
+                  className={`
+                  relative flex items-center justify-center w-10 h-10
                   border-4 border-foreground font-mono text-sm font-bold
                   transition-all
                   ${isCompleted ? "bg-primary text-primary-foreground" : ""}
@@ -64,43 +75,55 @@ export function WizardProgress({
                   ${isUpcoming ? "bg-muted text-muted-foreground" : ""}
                   ${isClickable ? "cursor-pointer hover:scale-110" : "cursor-not-allowed opacity-60"}
                 `}
-                animate={{
-                  scale: isActive ? [1, 1.1, 1] : 1,
-                }}
-                transition={{ duration: 0.3 }}
-                whileHover={isClickable ? { scale: 1.1 } : {}}
-                whileTap={isClickable ? { scale: 0.95 } : {}}
-                title={
-                  isClickable
-                    ? `Go to Step ${stepNumber}: ${step.title}`
-                    : "Complete previous steps first"
-                }
-              >
-                {isCompleted ? (
-                  <Check className="w-5 h-5" />
-                ) : (
-                  <span>{stepNumber}</span>
-                )}
-              </motion.button>
+                  layout
+                  initial={{ opacity: 0, scale: 0.8 }}
+                  animate={{
+                    opacity: 1,
+                    scale: isActive ? [1, 1.1, 1] : 1,
+                  }}
+                  exit={{ opacity: 0, scale: 0.8 }}
+                  transition={{ duration: 0.3 }}
+                  whileHover={isClickable ? { scale: 1.1 } : {}}
+                  whileTap={isClickable ? { scale: 0.95 } : {}}
+                  title={
+                    isClickable
+                      ? `Go to Step ${stepNumber}: ${step.title}`
+                      : "Complete previous steps first"
+                  }
+                >
+                  {isCompleted ? (
+                    <Check className="w-5 h-5" />
+                  ) : (
+                    <span>{stepNumber}</span>
+                  )}
+                </motion.button>
 
-              {/* Connecting line */}
-              {index < steps.length - 1 && (
-                <div className="flex-1 h-1 mx-2 bg-muted border-y-2 border-foreground relative overflow-hidden">
+                {/* Connecting line */}
+                {index < steps.length - 1 && (
                   <motion.div
-                    className="absolute inset-y-0 left-0 bg-primary"
-                    initial={{ width: "0%" }}
-                    animate={{
-                      width: isCompleted ? "100%" : "0%",
-                    }}
+                    key={`line-${step.id}`}
+                    className="h-1 bg-muted border-y-2 border-foreground relative overflow-hidden"
+                    layout
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
                     transition={{ duration: 0.3 }}
-                  />
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-
+                  >
+                    <motion.div
+                      className="absolute inset-y-0 left-0 bg-primary"
+                      initial={{ width: "0%" }}
+                      animate={{
+                        width: isCompleted ? "100%" : "0%",
+                      }}
+                      transition={{ duration: 0.3 }}
+                    />
+                  </motion.div>
+                )}
+              </>
+            );
+          })}
+        </AnimatePresence>
+      </motion.div>
       {/* Step title */}
       <div className="text-center">
         <span className="text-sm font-mono text-muted-foreground uppercase tracking-wider">

--- a/src/routes/wizard.tsx
+++ b/src/routes/wizard.tsx
@@ -1,7 +1,10 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, ErrorComponent } from "@tanstack/react-router";
 
 import { PromptWizard } from "@/components/prompt-wizard/PromptWizard";
+import { validateWizardSearch } from "@/utils/prompt-wizard/search-params";
 
 export const Route = createFileRoute("/wizard")({
+  validateSearch: validateWizardSearch,
   component: PromptWizard,
+  errorComponent: ErrorComponent,
 });


### PR DESCRIPTION
- Refactor WizardProgress to use CSS Grid for even step distribution
- Add AnimatePresence for smooth transitions between 5 and 10 steps
- Initialize wizard state from URL search params if available
- Auto-navigate to step 5 when disabling advanced mode from higher steps
- Export decompressFullState utility for URL state hydration
- Remove obsolete prompt-builder/advanced route from Header
- Fix progress bar wrapping by using grid gap instead of margins