### PR TITLE
fix: add required search params to wizard route links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,7 @@ export default function Header() {
             /> */}
             Home
           </Link>
-          <Link to="/wizard" className="ml-6">
+          <Link to="/wizard" search={{ d: null, vld: 0 }} className="ml-6">
             {/* <img
               src="/tanstack-word-logo-white.svg"
               alt="TanStack Logo"

--- a/src/components/landing/CTASection.tsx
+++ b/src/components/landing/CTASection.tsx
@@ -15,7 +15,11 @@ export function CTASection() {
           variant="secondary"
           className="text-lg px-10 py-7 h-auto uppercase font-black tracking-wide"
         >
-          <Link to="/wizard" className="flex items-center gap-3">
+          <Link
+            to="/wizard"
+            search={{ d: null, vld: 0 }}
+            className="flex items-center gap-3"
+          >
             Get Started Free
             <ArrowRight className="w-5 h-5" />
           </Link>

--- a/src/components/landing/Hero.tsx
+++ b/src/components/landing/Hero.tsx
@@ -39,7 +39,11 @@ export function Hero() {
             size="lg"
             className="text-lg px-10 py-7 h-auto uppercase font-black tracking-wide"
           >
-            <Link to="/wizard" className="flex items-center gap-3">
+            <Link
+              to="/wizard"
+              search={{ d: null, vld: 0 }}
+              className="flex items-center gap-3"
+            >
               Start Building
               <ArrowRight className="w-5 h-5" />
             </Link>

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -33,7 +33,7 @@ import { ToneStep } from "./steps/ToneStep";
 import { ReasoningStep } from "./steps/ReasoningStep";
 import { SelfCheckStep } from "./steps/SelfCheckStep";
 import { DisallowedStep } from "./steps/DisallowedStep";
-import { useSearch } from "@tanstack/react-router";
+import { Link, useSearch } from "@tanstack/react-router";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // STATIC CONFIGURATION
@@ -381,9 +381,9 @@ export const PromptWizard = memo(function PromptWizard() {
         {/* Back to Home */}
         <div className="mt-6 text-center">
           <Button variant="link" asChild>
-            <a href="/" className="text-muted-foreground font-mono text-sm">
+            <Link to="/" className="text-muted-foreground font-mono text-sm">
               ← Back to Home
-            </a>
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/routes/share.tsx
+++ b/src/routes/share.tsx
@@ -73,6 +73,7 @@ function ShareRouteComponent() {
             </p>
             <Link
               to="/wizard"
+              search={{ d: null, vld: 0 }}
               className="inline-block bg-primary text-primary-foreground font-bold uppercase px-6 py-3 border-4 border-foreground shadow-[4px_4px_0px_0px_hsl(var(--foreground))] hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0px_0px_hsl(var(--foreground))] transition-all"
             >
               Create New Prompt
@@ -92,7 +93,7 @@ function ShareRouteComponent() {
           source="share"
           shareUrl={shareUrl}
           onClose={() => {
-            navigate({ to: "/wizard" });
+            navigate({ to: "/wizard", search: { d: null, vld: 0 } });
           }}
         />
       </div>

--- a/src/utils/prompt-wizard/search-params.ts
+++ b/src/utils/prompt-wizard/search-params.ts
@@ -48,7 +48,7 @@ export const WIZARD_DEFAULTS: PromptWizardData = {
  * Compress wizard state to a single URL-safe string
  * Only includes non-default values
  */
-function compressFullState(data: Partial<PromptWizardData>): string {
+export function compressFullState(data: PromptWizardData): string {
   const filtered: Record<string, unknown> = {};
 
   for (const [key, value] of Object.entries(data)) {


### PR DESCRIPTION
- Add search={{ d: null, vld: 0 }} to all Link and navigate calls to /wizard
- Export compressFullState for use in WizardPreview
- Replace anchor tags with Link components for type safety
- Add Edit button to share route preview with proper routing