### PR TITLE
refactor(store): centralize advanced mode toggle and clean up unused getters

### DIFF
--- a/.changeset/cozy-months-cheat.md
+++ b/.changeset/cozy-months-cheat.md
@@ -1,0 +1,5 @@
+---
+"builder-prompt-ai": patch
+---
+
+Refactored wizard store to centralize advanced mode toggle logic and removed unused derived getters (`getPromptText`, `getCompressedData`). This ensures `total_steps` is updated atomically with `show_advanced`, preventing potential state inconsistencies.

--- a/.changeset/cozy-months-cheat.md
+++ b/.changeset/cozy-months-cheat.md
@@ -1,5 +1,0 @@
----
-"builder-prompt-ai": patch
----
-
-Refactored wizard store to centralize advanced mode toggle logic and removed unused derived getters (`getPromptText`, `getCompressedData`). This ensures `total_steps` is updated atomically with `show_advanced`, preventing potential state inconsistencies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1
+
+### Patch Changes
+
+- e1198c7: Refactored wizard store to centralize advanced mode toggle logic and removed unused derived getters (`getPromptText`, `getCompressedData`). This ensures `total_steps` is updated atomically with `show_advanced`, preventing potential state inconsistencies.
+
 ## 2.0.0
 
 ### Major Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "builder-prompt-ai",
   "private": true,
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
     "build": "vite build && cp instrument.server.mjs .vercel/output/server",

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -106,6 +106,7 @@ export const PromptWizard = memo(function PromptWizard() {
   const initialize = useWizardStore((state) => state.initialize);
   const isCurrentStepValid = useWizardStore((state) => state.isCurrentStepValid);
   const getCurrentStepError = useWizardStore((state) => state.getCurrentStepError);
+  const toggleAdvancedMode = useWizardStore((state) => state.toggleAdvancedMode);
 
   // ─────────────────────────────────────────────────────────────────────────
   // Initialization
@@ -220,10 +221,6 @@ export const PromptWizard = memo(function PromptWizard() {
     }
   }, [currentStepValid, wizardData, setShowError, finish, trackEvent, isMobile]);
 
-  const toggleAdvanced = useCallback(() => {
-    updateData({ show_advanced: !showAdvanced });
-  }, [showAdvanced, updateData]);
-
   const handleReset = useCallback(() => {
     trackEvent("data_reset", {
       page: "wizard",
@@ -294,7 +291,7 @@ export const PromptWizard = memo(function PromptWizard() {
                   <Switch
                     id="advanced-mode"
                     checked={showAdvanced}
-                    onCheckedChange={toggleAdvanced}
+                    onCheckedChange={toggleAdvancedMode}
                   />
                   <Label htmlFor="advanced-mode" className="text-sm font-mono">
                     <Settings2 className="w-4 h-4 inline mr-1" />


### PR DESCRIPTION
## Summary

Refactors the wizard store to improve state management correctness and remove dead code.

## Changes

### [src/stores/wizard-store.ts](cci:7://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/stores/wizard-store.ts:0:0-0:0)
- **Added** `toggleAdvancedMode` action that atomically updates both `show_advanced` and `total_steps`
- **Removed** unused derived getters: `getPromptText` and `getCompressedData`
- **Removed** `total_steps` update from `updateData` action (was causing inconsistent state)

### [src/components/prompt-wizard/PromptWizard.tsx](cci:7://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/components/prompt-wizard/PromptWizard.tsx:0:0-0:0)
- **Replaced** inline `toggleAdvanced` callback with store's `toggleAdvancedMode` action
- **Simplified** component by removing local state manipulation logic

## Motivation

The previous implementation had `total_steps` being updated in `updateData` whenever `show_advanced` changed, but this was error-prone as not all toggle scenarios went through `updateData`. By creating a dedicated `toggleAdvancedMode` action, we ensure atomicity and prevent state inconsistencies.

## Testing

- [x] Toggle advanced mode on/off and verify step count updates correctly
- [x] Navigate through wizard steps in both basic and advanced modes