### PR TITLE
feat(storage): add finishedAt tracking, improve storage deduplication, and enhance wizard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@tanstack/router-plugin": "^1.132.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "fastest-levenshtein": "^1.0.16",
     "lucide-react": "^0.544.0",
     "lz-string": "^1.5.0",
     "mixpanel": "^0.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      fastest-levenshtein:
+        specifier: ^1.0.16
+        version: 1.0.16
       lucide-react:
         specifier: ^0.544.0
         version: 0.544.0(react@19.2.0)
@@ -2527,6 +2530,10 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -6417,6 +6424,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fastest-levenshtein@1.0.16: {}
 
   fastq@1.19.1:
     dependencies:

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -258,6 +258,7 @@ export const PromptWizard = memo(function PromptWizard() {
   };
 
   const handleResetCore = useCallback(() => {
+    setIsResetCalled(false);
     trackEvent("data_reset", {
       page: "wizard",
       timestamp: new Date().toISOString(),

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -451,7 +451,12 @@ export const PromptWizard = memo(function PromptWizard() {
         </AlertDialog>
 
         {/* Stored Prompts (only shows if user has saved prompts) */}
-        <StoredPromptsSection page="wizard" columns={3} currentPrompt={wizardData} />
+        <StoredPromptsSection
+          page="wizard"
+          columns={3}
+          currentPrompt={wizardData}
+          key={wizardData.finishedAt}
+        />
       </div>
     </div>
   );

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -218,7 +218,6 @@ export const PromptWizard = memo(function PromptWizard() {
         timestamp: new Date().toISOString(),
         step: currentStep + 1,
       });
-      storeWizardDataInLocalStorage();
     }
   }, [currentStep, totalSteps, currentStepValid, goToStep, setShowError, trackEvent]);
 
@@ -230,7 +229,6 @@ export const PromptWizard = memo(function PromptWizard() {
         timestamp: new Date().toISOString(),
         step: currentStep - 1,
       });
-      storeWizardDataInLocalStorage();
     }
   }, [currentStep, goToStep, trackEvent]);
 
@@ -278,7 +276,6 @@ export const PromptWizard = memo(function PromptWizard() {
           timestamp: new Date().toISOString(),
           step,
         });
-        storeWizardDataInLocalStorage();
         return;
       }
       if (step > currentStep && !currentStepValid) {
@@ -291,7 +288,6 @@ export const PromptWizard = memo(function PromptWizard() {
         timestamp: new Date().toISOString(),
         step,
       });
-      storeWizardDataInLocalStorage();
     },
     [currentStep, currentStepValid, goToStep, setShowError, trackEvent]
   );

--- a/src/components/prompt-wizard/WizardNavigation.tsx
+++ b/src/components/prompt-wizard/WizardNavigation.tsx
@@ -23,7 +23,6 @@ export function WizardNavigation({
 }: WizardNavigationProps) {
   const totalSteps = showAdvanced ? 10 : TOTAL_REQUIRED_STEPS;
   const isFirstStep = currentStep === 1;
-  const isLastStep = currentStep === totalSteps;
   const hasFinished = useWizardStore((store) => store.wizardData.finishedAt !== -1);
 
   return (
@@ -47,24 +46,22 @@ export function WizardNavigation({
       {/* Next / Finish button */}
       <div className="flex items-center justify-between gap-4">
         <motion.div
-          whileHover={!canProceed || isLastStep ? {} : { x: 4 }}
-          whileTap={!canProceed || isLastStep ? {} : { scale: 0.98 }}
+          whileHover={!canProceed ? {} : { x: 4 }}
+          whileTap={!canProceed ? {} : { scale: 0.98 }}
         >
-          <Button
-            onClick={onNext}
-            disabled={!canProceed || isLastStep}
-            className="uppercase font-bold"
-          >
+          <Button onClick={onNext} disabled={!canProceed} className="uppercase font-bold">
             Next
             <ArrowRight className="w-4 h-4 ml-2" />
           </Button>
         </motion.div>
-        <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-          <Button onClick={onFinish} disabled={!canProceed} className="uppercase font-bold">
-            <Sparkles className="w-4 h-4 mr-2" />
-            Save Prompt
-          </Button>
-        </motion.div>
+        {hasFinished && (
+          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+            <Button onClick={onFinish} disabled={!canProceed} className="uppercase font-bold">
+              <Sparkles className="w-4 h-4 mr-2" />
+              Save Prompt
+            </Button>
+          </motion.div>
+        )}
       </div>
     </div>
   );

--- a/src/components/prompt-wizard/WizardNavigation.tsx
+++ b/src/components/prompt-wizard/WizardNavigation.tsx
@@ -23,6 +23,7 @@ export function WizardNavigation({
 }: WizardNavigationProps) {
   const totalSteps = showAdvanced ? 10 : TOTAL_REQUIRED_STEPS;
   const isFirstStep = currentStep === 1;
+  const isLastStep = currentStep === totalSteps;
   const hasFinished = useWizardStore((store) => store.wizardData.finishedAt !== -1);
 
   return (
@@ -54,14 +55,16 @@ export function WizardNavigation({
             <ArrowRight className="w-4 h-4 ml-2" />
           </Button>
         </motion.div>
-        {hasFinished && (
-          <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
-            <Button onClick={onFinish} disabled={!canProceed} className="uppercase font-bold">
-              <Sparkles className="w-4 h-4 mr-2" />
-              Save Prompt
-            </Button>
-          </motion.div>
-        )}
+        <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
+          <Button
+            onClick={onFinish}
+            disabled={!(canProceed || hasFinished || isLastStep)}
+            className="uppercase font-bold"
+          >
+            <Sparkles className="w-4 h-4 mr-2" />
+            Save Prompt
+          </Button>
+        </motion.div>
       </div>
     </div>
   );

--- a/src/stores/wizard-store.ts
+++ b/src/stores/wizard-store.ts
@@ -1,12 +1,13 @@
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 import { toast } from "sonner";
+import { distance } from "fastest-levenshtein";
 
 import type { PromptWizardData, StoredPrompt, PromptStorageV2 } from "@/utils/prompt-wizard/schema";
 import { TOTAL_REQUIRED_STEPS } from "@/utils/prompt-wizard/schema";
 import { compress, decompress } from "@/utils/prompt-wizard/url-compression";
 import { decompressFullState, WIZARD_DEFAULTS } from "@/utils/prompt-wizard/search-params";
-import { getOrCreateSessionId } from "@/utils/session";
+import { generateSessionId, getOrCreateSessionId } from "@/utils/session";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -53,6 +54,9 @@ function loadFromStorage(): [PromptWizardData, "default" | "localStorage"] {
       if (!decompressed) return [WIZARD_DEFAULTS, "default"];
       json = decompressed;
     }
+
+    localStorage.setItem(`_${STORAGE_KEY}_`, stored);
+    localStorage.removeItem(STORAGE_KEY);
 
     return [{ ...WIZARD_DEFAULTS, ...JSON.parse(json) }, "localStorage"];
   } catch {
@@ -131,9 +135,17 @@ function loadPromptsV2(): PromptStorageV2 {
     }
 
     const parsed = JSON.parse(json) as PromptStorageV2;
+    let parsedPrompts = Array.isArray(parsed.prompts)
+      ? parsed.prompts.filter((prompt) => {
+          if (!prompt.data.task_intent || prompt.data.updatedAt === -1) {
+            return false;
+          }
+          return true;
+        })
+      : [];
     return {
       version: parsed.version || "v2",
-      prompts: Array.isArray(parsed.prompts) ? parsed.prompts : [],
+      prompts: parsedPrompts,
     };
   } catch {
     return getDefaultStorageV2();
@@ -192,11 +204,26 @@ export function upsertPromptV2(
   const storage = loadPromptsV2();
   const storageUpdated = { ...storage };
 
-  const promptStr = JSON.stringify(data);
+  const { id, ...dataWithoutId } = data;
+
+  const promptStr = JSON.stringify(dataWithoutId);
   let promptIndex: number = -1;
   let index = 0;
   for (const promptStored of storageUpdated.prompts) {
-    if (JSON.stringify(promptStored.data) === promptStr) {
+    const {
+      data: { id: _id, ...promptStoredDataWithoutId },
+    } = promptStored;
+    if (id && _id && id === _id) {
+      promptIndex = index;
+      break;
+    }
+    const promptStoredDataString = JSON.stringify(promptStoredDataWithoutId);
+    if (promptStoredDataString === promptStr) {
+      promptIndex = index;
+      break;
+    }
+    const levenshteinDistanceVal = distance(promptStoredDataString, promptStr);
+    if (levenshteinDistanceVal < 10) {
       promptIndex = index;
       break;
     }
@@ -210,13 +237,21 @@ export function upsertPromptV2(
   };
   if (promptIndex === -1) {
     // Add to end (LRU: most recent at end)
+    if (!confirm("Are you sure you want to add?")) {
+      return;
+    }
     storageUpdated.prompts.push(newPrompt);
   } else {
     storageUpdated.prompts[promptIndex] = newPrompt;
   }
-  storageUpdated.prompts = storageUpdated.prompts.sort(
-    (a, b) => a.data.updatedAt.valueOf() - b.data.updatedAt.valueOf()
-  );
+  storageUpdated.prompts = storageUpdated.prompts
+    .map((prompt) => {
+      if (!prompt.data.id) {
+        prompt.data.id = generateSessionId();
+      }
+      return prompt;
+    })
+    .sort((a, b) => a.data.updatedAt.valueOf() - b.data.updatedAt.valueOf());
 
   savePromptsV2(storageUpdated);
   callbackMap.onSuccess();
@@ -517,27 +552,27 @@ export const useWizardStore = create<WizardStore>()(
 // DEBOUNCED PERSISTENCE SUBSCRIBER
 // ═══════════════════════════════════════════════════════════════════════════
 
-let saveTimeoutId: ReturnType<typeof setTimeout> | undefined;
+// let saveTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
-useWizardStore.subscribe(
-  (state) => state.wizardData,
-  (wizardData) => {
-    if (saveTimeoutId) {
-      clearTimeout(saveTimeoutId);
-    }
-    saveTimeoutId = setTimeout(() => {
-      upsertPromptV2(
-        wizardData,
-        {
-          noTaskIntent: () => {},
-          onSuccess: () => {
-            toast.success("Prompt saved!");
-          },
-        },
-        {
-          shouldExecute: true,
-        }
-      );
-    }, 800);
-  }
-);
+// useWizardStore.subscribe(
+//   (state) => state.wizardData,
+//   (wizardData) => {
+//     if (saveTimeoutId) {
+//       clearTimeout(saveTimeoutId);
+//     }
+//     saveTimeoutId = setTimeout(() => {
+//       upsertPromptV2(
+//         wizardData,
+//         {
+//           noTaskIntent: () => {},
+//           onSuccess: () => {
+//             toast.success("Prompt saved!");
+//           },
+//         },
+//         {
+//           shouldExecute: true,
+//         }
+//       );
+//     }, 800);
+//   }
+// );

--- a/src/stores/wizard-store.ts
+++ b/src/stores/wizard-store.ts
@@ -237,9 +237,6 @@ export function upsertPromptV2(
   };
   if (promptIndex === -1) {
     // Add to end (LRU: most recent at end)
-    if (!confirm("Are you sure you want to add?")) {
-      return;
-    }
     storageUpdated.prompts.push(newPrompt);
   } else {
     storageUpdated.prompts[promptIndex] = newPrompt;

--- a/src/utils/prompt-wizard/schema.ts
+++ b/src/utils/prompt-wizard/schema.ts
@@ -136,6 +136,7 @@ export const promptWizardSchema = z.object({
   show_advanced: z.boolean().default(false),
   updatedAt: z.number().default(-1),
   finishedAt: z.number().default(-1),
+  id: z.string().optional(),
 });
 
 export type PromptWizardData = z.infer<typeof promptWizardSchema>;

--- a/src/utils/session.ts
+++ b/src/utils/session.ts
@@ -9,7 +9,7 @@ const COOKIE_MAX_AGE = 365 * 24 * 60 * 60; // 1 year in seconds
 /**
  * Generates a unique session ID using crypto.randomUUID()
  */
-function generateSessionId(): string {
+export function generateSessionId(): string {
   return crypto.randomUUID();
 }
 


### PR DESCRIPTION
## Summary
Bug fixes and improvements for v2 prompt storage and wizard UX.

## Changes

### Storage
- Add `finishedAt` field to track when prompts are completed
- Improve [upsertPromptV2](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/stores/wizard-store.ts:175:0-254:1) with callback-based API and full data comparison
- Migrate legacy `wizard-draft` storage on read (backward compat)
- Sort stored prompts by `updatedAt` timestamp

### Wizard Navigation
- Show "Save Prompt" button on all steps (enabled when valid/finished)
- Always visible Back/Next buttons (disabled when appropriate)
- Remove redundant [storeWizardDataInLocalStorage](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/components/prompt-wizard/PromptWizard.tsx:111:2-124:4) calls

### Hook Improvements
- Filter prompts with missing `task_intent` or `updatedAt`
- Use `title` instead of `taskIntent` for deduplication
- Key [StoredPromptsSection](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/components/prompt-wizard/StoredPromptsSection.tsx:29:0-135:1) by `finishedAt` for reactivity

### Debugging
- Add Sentry error tracking and console logs to share route validation