### PR TITLE
refactor(wizard): simplify state management by eliminating prop drilling

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,43 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Debug in Chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "sourceMapPathOverrides": {
+        "webpack://*": "${webRoot}/*"
+      }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Server (SSR)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["dev"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Tests (Vitest)",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["test", "--", "--run", "--reporter=verbose"],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal",
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Full Stack Debug",
+      "configurations": ["Debug Server (SSR)", "Debug in Chrome"],
+      "stopAll": true
+    }
+  ]
+}

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -125,7 +125,6 @@ export const PromptWizard = memo(function PromptWizard() {
   };
   const shareUrl = useWizardStore((state) => state.shareUrl);
   const showError = useWizardStore((state) => state.showError);
-  const completedSteps = useWizardStore((state) => state.completedSteps);
 
   const updateData = useWizardStore((state) => state.updateData);
   const goToStep = useWizardStore((state) => state.goToStep);
@@ -194,9 +193,12 @@ export const PromptWizard = memo(function PromptWizard() {
   // ─────────────────────────────────────────────────────────────────────────
   // Derived Values
   // ─────────────────────────────────────────────────────────────────────────
-  const currentStep = wizardData.step;
-  const showAdvanced = wizardData.show_advanced;
-  const totalSteps = wizardData.total_steps;
+  const {
+    updatedAt,
+    step: currentStep,
+    show_advanced: showAdvanced,
+    total_steps: totalSteps,
+  } = wizardData;
 
   const currentStepValid = isCurrentStepValid();
   const currentStepError = getCurrentStepError();
@@ -331,6 +333,7 @@ export const PromptWizard = memo(function PromptWizard() {
                   <div className="flex items-center gap-2">
                     <Switch
                       id="advanced-mode"
+                      key={updatedAt}
                       checked={showAdvanced}
                       onCheckedChange={toggleAdvancedMode}
                     />
@@ -341,12 +344,7 @@ export const PromptWizard = memo(function PromptWizard() {
                   </div>
                 </div>
               </div>
-              <WizardProgress
-                currentStep={currentStep}
-                totalSteps={totalSteps}
-                completedSteps={completedSteps}
-                onStepClick={handleStepClick}
-              />
+              <WizardProgress onStepClick={handleStepClick} />
             </div>
 
             {/* Step Content */}
@@ -369,8 +367,6 @@ export const PromptWizard = memo(function PromptWizard() {
             {/* Navigation */}
             <div className="p-6">
               <WizardNavigation
-                currentStep={currentStep}
-                showAdvanced={showAdvanced}
                 onNext={handleNext}
                 onBack={handleBack}
                 onFinish={handleFinish}

--- a/src/components/prompt-wizard/WizardNavigation.tsx
+++ b/src/components/prompt-wizard/WizardNavigation.tsx
@@ -1,12 +1,9 @@
 import { motion } from "motion/react";
 import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { TOTAL_REQUIRED_STEPS } from "@/utils/prompt-wizard/schema";
 import { useWizardStore } from "@/stores/wizard-store";
 
 interface WizardNavigationProps {
-  currentStep: number;
-  showAdvanced: boolean;
   onNext: () => void;
   onBack: () => void;
   onFinish: () => void;
@@ -14,14 +11,13 @@ interface WizardNavigationProps {
 }
 
 export function WizardNavigation({
-  currentStep,
-  showAdvanced,
   onNext,
   onBack,
   onFinish,
   canProceed = true,
 }: WizardNavigationProps) {
-  const totalSteps = showAdvanced ? 10 : TOTAL_REQUIRED_STEPS;
+  const currentStep = useWizardStore((state) => state.wizardData.step);
+  const totalSteps = useWizardStore((state) => state.wizardData.total_steps);
   const isFirstStep = currentStep === 1;
   const isLastStep = currentStep === totalSteps;
   const hasFinished = useWizardStore((store) => store.wizardData.finishedAt !== -1);

--- a/src/utils/prompt-wizard/schema.ts
+++ b/src/utils/prompt-wizard/schema.ts
@@ -132,7 +132,7 @@ export const promptWizardSchema = z.object({
   // Wizard State
   // ─────────────────────────────────────────────────────────────────────────
   step: z.number().min(1).max(10).default(1),
-  total_steps: z.number().min(1).max(10).default(1),
+  total_steps: z.number().min(1).max(10).default(5),
   show_advanced: z.boolean().default(false),
   updatedAt: z.number().default(-1),
   finishedAt: z.number().default(-1),
@@ -161,19 +161,24 @@ export type PromptWizardSearchParamsCompressed =
 // STEP DEFINITIONS
 // ═══════════════════════════════════════════════════════════════════════════
 
-export const WIZARD_STEPS = [
-  // Required steps
+export const WIZARD_STEPS_REQUIRED = [
   { id: 1, key: "task_intent", title: "What do you want?", required: true },
   { id: 2, key: "context", title: "Give some context", required: true },
   { id: 3, key: "constraints", title: "Any constraints?", required: true },
   { id: 4, key: "target_audience", title: "Who is this for?", required: true },
   { id: 5, key: "output_format", title: "Output format", required: true },
+];
+
+export const WIZARD_STEPS = [
+  // Required steps
+  ...WIZARD_STEPS_REQUIRED,
   // Optional steps
   { id: 6, key: "ai_role", title: "AI Role", required: false },
   { id: 7, key: "tone_style", title: "Tone & Style", required: false },
   { id: 8, key: "reasoning_depth", title: "Reasoning Depth", required: false },
   { id: 9, key: "self_check", title: "Self-Check", required: false },
   { id: 10, key: "disallowed_content", title: "Avoid", required: false },
+  ,
 ] as const;
 
 export const REQUIRED_STEPS = WIZARD_STEPS.filter((s) => s.required);


### PR DESCRIPTION
## Summary

Refactors the Prompt Wizard progress and navigation components to read state directly from Zustand store, eliminating unnecessary prop drilling from the parent component.

## Changes

### State Management
- **WizardProgress**: Now reads `currentStep`, `totalSteps`, `showAdvanced`, `completedSteps`, and `updatedAt` directly from `useWizardStore`
- **WizardNavigation**: Now reads `currentStep` and `totalSteps` directly from `useWizardStore`
- Removed redundant props from parent `PromptWizard.tsx`

### Schema Updates
- Extracted `WIZARD_STEPS_REQUIRED` constant for the 5 required steps
- `WIZARD_STEPS` now spreads required steps and adds optional ones
- Fixed default value for `total_steps` to `5` (matching required step count)

### Bug Fixes
- Fixed `isClickable` logic in WizardProgress for proper step navigation

### Developer Experience
- Added VS Code launch.json for debugging Next.js (server, client, and full-stack configurations)

## Testing

- [ ] Wizard step navigation works correctly
- [ ] Advanced mode toggle shows/hides optional steps
- [ ] Step clicking respects completion state