### PR TITLE
refactor(storage): remove legacy v1 storage handling and simplify wizard-store

### DIFF
--- a/.changeset/small-planets-burn.md
+++ b/.changeset/small-planets-burn.md
@@ -1,0 +1,5 @@
+---
+"builder-prompt-ai": minor
+---
+
+refactor(storage): remove legacy v1 storage handling and simplify wizard-store

--- a/.changeset/small-planets-burn.md
+++ b/.changeset/small-planets-burn.md
@@ -1,5 +1,0 @@
----
-"builder-prompt-ai": minor
----
-
-refactor(storage): remove legacy v1 storage handling and simplify wizard-store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.3.0
+
+### Minor Changes
+
+- 1ee0911: refactor(storage): remove legacy v1 storage handling and simplify wizard-store
+
 ## 3.2.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "builder-prompt-ai",
   "private": true,
   "type": "module",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "scripts": {
     "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
     "build": "vite build && cp instrument.server.mjs .vercel/output/server",

--- a/src/hooks/usePromptsWithFallback.ts
+++ b/src/hooks/usePromptsWithFallback.ts
@@ -7,7 +7,7 @@ import { EXAMPLE_PROMPTS } from "@/data/example-prompts";
 import { compressPrompt } from "@/utils/prompt-wizard/url-compression";
 import type { PromptWizardData } from "@/utils/prompt-wizard";
 
-const { loadPromptsV2, loadFromStorage, deletePromptV2 } = __testing;
+const { loadPromptsV2, deletePromptV2 } = __testing;
 
 // ═══════════════════════════════════════════════════════════════════════════
 // TYPES
@@ -70,29 +70,6 @@ function loadStoredPrompts(): { items: StoredPromptCardItem[]; source: "stored" 
     });
 
     return { items: deduped, source: "stored" };
-  }
-
-  // 2. Try v1 prompt (single prompt in wizard-draft)
-  const [v1Data, v1Source] = loadFromStorage();
-  if (v1Source === "localStorage" && v1Data.task_intent) {
-    const taskIntent = v1Data.task_intent;
-    const title = taskIntent.length > 40 ? `${taskIntent.slice(0, 40)}...` : taskIntent;
-    const description = v1Data.context?.slice(0, 80) || "No context provided";
-
-    return {
-      items: [
-        {
-          id: "stored-v1-0",
-          title,
-          description,
-          icon: FileText,
-          color: "bg-primary",
-          compressedData: compressPrompt({ ...v1Data, examples: "", step: 1, finishedAt: -1 }),
-          originalIndex: 0,
-        },
-      ],
-      source: "stored",
-    };
   }
 
   return { items: [], source: null };


### PR DESCRIPTION
- Remove deprecated `loadFromStorage`, `clearStorage`, `saveShareUrl`, `getShareUrl` functions
- Remove legacy v1 prompt handling from [usePromptsWithFallback](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/hooks/usePromptsWithFallback.ts:81:0-147:1)
- Simplify storage parsing by removing uncompressed JSON fallback
- Use [compressPrompt](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/utils/prompt-wizard/url-compression.ts:30:0-34:1) directly in [generateShareUrl](cci:1://file:///Users/santoshvenkatraman/Personal/Coding/builder-prompt-ai/src/stores/wizard-store.ts:276:0-289:1)
- Remove redundant `console.log` statement from analytics example