### PR TITLE
feat: implement save-to-unlock pattern and consolidate save logic

### DIFF
--- a/.changeset/bumpy-boxes-melt.md
+++ b/.changeset/bumpy-boxes-melt.md
@@ -1,0 +1,5 @@
+---
+"builder-prompt-ai": minor
+---
+
+This PR introduces the "Save-to-Unlock" pattern, ensuring key features like Copy, Share, and ChatGPT integration are locked until the prompt is saved. It also consolidates the save logic into the value of truth components.

--- a/.changeset/bumpy-boxes-melt.md
+++ b/.changeset/bumpy-boxes-melt.md
@@ -1,5 +1,0 @@
----
-"builder-prompt-ai": minor
----
-
-This PR introduces the "Save-to-Unlock" pattern, ensuring key features like Copy, Share, and ChatGPT integration are locked until the prompt is saved. It also consolidates the save logic into the value of truth components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.5.0
+
+### Minor Changes
+
+- 801fede: This PR introduces the "Save-to-Unlock" pattern, ensuring key features like Copy, Share, and ChatGPT integration are locked until the prompt is saved. It also consolidates the save logic into the value of truth components.
+
 ## 4.4.0
 
 ### Minor Changes

--- a/convex/prompts.ts
+++ b/convex/prompts.ts
@@ -199,3 +199,16 @@ export const getPromptBySlug = query({
     return prompt;
   },
 });
+
+export const getPromptsBySessionId = query({
+  args: { sessionId: v.string() },
+  handler: async (ctx, args) => {
+    const prompts = await ctx.db
+      .query("prompts")
+      .withIndex("by_session_hash", (q) => q.eq("sessionId", args.sessionId))
+      .order("desc")
+      .collect();
+
+    return prompts;
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "builder-prompt-ai",
   "private": true,
   "type": "module",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "scripts": {
     "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
     "build": "vite build && cp instrument.server.mjs .vercel/output/server",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,7 +20,7 @@ export default function Header() {
           <Menu size={24} />
         </button>
         <h1 className="ml-4 text-xl font-semibold">
-          <Link to="/">
+          <Link to="/" reloadDocument>
             {/* <img
               src="/tanstack-word-logo-white.svg"
               alt="TanStack Logo"
@@ -28,7 +28,12 @@ export default function Header() {
             /> */}
             Home
           </Link>
-          <Link to="/wizard" search={{ d: null, vld: 0, partial: false }} className="ml-6">
+          <Link
+            to="/wizard"
+            search={{ d: null, vld: 0, partial: false }}
+            className="ml-6"
+            reloadDocument
+          >
             {/* <img
               src="/tanstack-word-logo-white.svg"
               alt="TanStack Logo"
@@ -58,6 +63,7 @@ export default function Header() {
         <nav className="flex-1 p-4 overflow-y-auto">
           <Link
             to="/"
+            reloadDocument
             onClick={() => setIsOpen(false)}
             className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-800 transition-colors mb-2"
             activeProps={{

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -12,7 +12,9 @@ export function NotFound() {
             The page you are looking for does not exist or has been moved.
           </p>
           <Button asChild size="lg" className="w-full uppercase font-bold text-md">
-            <Link to="/">Go Home</Link>
+            <Link to="/" reloadDocument>
+              Go Home
+            </Link>
           </Button>
         </div>
       </div>

--- a/src/components/landing/v2/PromptPreview.tsx
+++ b/src/components/landing/v2/PromptPreview.tsx
@@ -84,7 +84,12 @@ function EmptyState({ onSelectExampleClick }: { onSelectExampleClick?: () => voi
           Select Example
         </button>
 
-        <Link to="/wizard" search={{ d: null, vld: 0, partial: false }} className="block w-full">
+        <Link
+          to="/wizard"
+          search={{ d: null, vld: 0, partial: false }}
+          reloadDocument
+          className="block w-full"
+        >
           <div
             className={cn(
               "flex items-center justify-center gap-2 px-8 py-4 bg-primary text-primary-foreground",
@@ -102,6 +107,7 @@ function EmptyState({ onSelectExampleClick }: { onSelectExampleClick?: () => voi
       <Link
         to="/wizard"
         search={{ d: null, vld: 0, partial: false }}
+        reloadDocument
         className="hidden md:inline-block"
       >
         <div

--- a/src/components/prompt-wizard/AnalysisPanel.tsx
+++ b/src/components/prompt-wizard/AnalysisPanel.tsx
@@ -119,7 +119,7 @@ export function AnalysisPanel({ promptAnalysisResult }: AnalysisPanelProps) {
         <CardFooter className="flex-col items-start border-t pt-4 bg-muted/10">
           <p className="text-sm font-medium mb-2">Improved Version Idea:</p>
           <div className="text-xs bg-muted p-3 rounded-md w-full whitespace-pre-wrap font-mono relative group">
-            {generatePromptText(promptAnalysisResult.improvedPromptData)}
+            {generatePromptText(promptAnalysisResult.improvedPromptData, "AnalysisPanel")}
             <Button
               variant="secondary"
               size="sm"

--- a/src/components/prompt-wizard/PromptWizard.tsx
+++ b/src/components/prompt-wizard/PromptWizard.tsx
@@ -428,7 +428,7 @@ export const PromptWizard = memo(function PromptWizard() {
   }, []);
 
   const isPromptAvailable = useMemo(() => {
-    return generatePromptText(wizardData).trim().length > 0;
+    return generatePromptText(wizardData, "PromptWizard").trim().length > 0;
   }, [wizardData.updatedAt]);
 
   // Get step component and props

--- a/src/components/prompt-wizard/WizardNavigation.tsx
+++ b/src/components/prompt-wizard/WizardNavigation.tsx
@@ -43,26 +43,14 @@ export function WizardNavigation({
 
       {/* Next / Finish button */}
       <div className="flex flex-col md:flex-row items-center justify-between gap-3 w-full md:w-auto">
-        {!isLastStep && (
-          <motion.div whileHover={{ x: 4 }} whileTap={{ scale: 0.98 }} className="w-full md:w-auto">
-            <Button onClick={onNext} className="uppercase font-bold w-full md:w-auto">
-              Next
-              <ArrowRight className="w-4 h-4 ml-2" />
-            </Button>
-          </motion.div>
-        )}
-        <motion.div
-          whileHover={{ scale: 1.02 }}
-          whileTap={{ scale: 0.98 }}
-          className="w-full md:w-auto"
-        >
+        <motion.div whileHover={{ x: 4 }} whileTap={{ scale: 0.98 }} className="w-full md:w-auto">
           <Button
-            onClick={onFinish}
+            onClick={onNext}
+            disabled={isLastStep || !isPromptAvailable}
             className="uppercase font-bold w-full md:w-auto"
-            disabled={!isPromptAvailable}
           >
-            <Sparkles className="w-4 h-4 mr-2" />
-            Save Prompt
+            Next
+            <ArrowRight className="w-4 h-4 ml-2" />
           </Button>
         </motion.div>
       </div>

--- a/src/components/prompt-wizard/WizardNavigation.tsx
+++ b/src/components/prompt-wizard/WizardNavigation.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 import { useWizardStore, generatePromptText } from "@/stores/wizard-store";
@@ -15,12 +15,11 @@ interface WizardNavigationProps {
 export function WizardNavigation({
   onNext,
   onBack,
-  onFinish,
   isFirstStep,
   isLastStep,
 }: WizardNavigationProps) {
   const wizardData = useWizardStore((state) => state.wizardData);
-  const isPromptAvailable = generatePromptText(wizardData).trim().length > 0;
+  const isPromptAvailable = generatePromptText(wizardData, "WizardNavigation").trim().length > 0;
 
   return (
     <div className="flex flex-col md:flex-row items-center justify-between gap-4 pt-6 border-t-4 border-foreground">

--- a/src/components/prompt-wizard/WizardPreview.tsx
+++ b/src/components/prompt-wizard/WizardPreview.tsx
@@ -1,7 +1,17 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 
 import { motion } from "motion/react";
-import { Copy, Check, ExternalLink, FilePen, Bot, Share2, Loader2, Sparkles } from "lucide-react";
+import {
+  Copy,
+  Check,
+  ExternalLink,
+  FilePen,
+  Bot,
+  Share2,
+  Loader2,
+  Sparkles,
+  Save,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -29,7 +39,12 @@ import { useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { getOrCreateSessionId } from "@/utils/session";
 import type { PromptWizardData } from "@/utils/prompt-wizard/schema";
-import { compressPrompt, decompressPrompt } from "@/utils/prompt-wizard";
+import {
+  compressPrompt,
+  decompressPrompt,
+  partialPromptWizardSchema,
+  promptWizardSchema,
+} from "@/utils/prompt-wizard";
 import { Link } from "@tanstack/react-router";
 import { useTrackMixpanel } from "@/utils/analytics/MixpanelProvider";
 import { generatePromptText } from "@/stores/wizard-store";
@@ -39,6 +54,8 @@ import { NavigationActions } from "./NavigationActions";
 import { useServerFn } from "@tanstack/react-start";
 import { analyzePrompt, type PromptEvaluationTransformed } from "@/functions/analyze-prompt";
 import { AnalysisPanel } from "./AnalysisPanel";
+import { env } from "@/utils/client/env";
+import { Logger } from "@/utils/logger";
 
 export type WizardPreviewPropsForSharePage = {
   shareUrl?: string; // made optional
@@ -293,6 +310,12 @@ export function WizardPreviewForSharePage(props: WizardPreviewPropsForSharePage)
   );
 }
 
+const wizardPreviewLogger = Logger.createLogger({
+  namespace: "WizardPreview",
+  level: "DEBUG",
+  enableConsoleLog: true,
+});
+
 function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
   const { data } = props;
   const trackEvent = useTrackMixpanel();
@@ -312,9 +335,38 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
 
   // KEY FIX: Use useMemo instead of useState(() => ...)
   // This ensures promptText re-computes whenever `data` changes
-  const [promptText, wizardData, promptTextCompressed] = useMemo(() => {
-    const wizardData = data as PromptWizardData;
-    return [generatePromptText(wizardData), wizardData, compressPrompt(wizardData)];
+  const [promptText, wizardData, promptTextCompressed, isPromptValid] = useMemo(() => {
+    let wizardData = data as PromptWizardData;
+    wizardPreviewLogger.debug("wizardData", wizardData);
+    const promptText = generatePromptText(wizardData);
+    let isPromptValid = promptText.length > 0;
+    wizardPreviewLogger.debug("promptText", promptText);
+    if (!promptText.length) {
+      wizardPreviewLogger.debug("isPromptValid", isPromptValid);
+      return ["", wizardData, "", false];
+    }
+    if (!wizardData.output_format) {
+      wizardPreviewLogger.debug("wizardData.output_format before", wizardData.output_format);
+      wizardData = {
+        ...wizardData,
+        output_format: "bullet-list",
+      };
+      wizardPreviewLogger.debug("wizardData.output_format after", wizardData.output_format);
+    }
+    const result1 = promptWizardSchema.safeParse(wizardData);
+    isPromptValid = result1.success;
+    wizardPreviewLogger.debug("isPromptValid", isPromptValid);
+    if (!isPromptValid) {
+      const result2 = partialPromptWizardSchema.safeParse(wizardData);
+      wizardPreviewLogger.debug("result2", result2);
+      isPromptValid = result2.success;
+    }
+    wizardPreviewLogger.debug("isPromptValid", isPromptValid);
+    wizardPreviewLogger.debug("result1", result1);
+    if (!isPromptValid) {
+      return ["", wizardData, "", false];
+    }
+    return [promptText, wizardData, compressPrompt(wizardData), isPromptValid];
   }, [data]);
 
   const hasUserInteracted = wizardData.updatedAt > -1;
@@ -322,6 +374,10 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
   const handleCopyPrompt = useCallback(async () => {
     if (!hasUserInteracted) {
       toast.error("Please interact with the wizard before copying the prompt");
+      return;
+    }
+    if (!isPromptValid) {
+      toast.error("Please fill in all the required fields");
       return;
     }
     try {
@@ -336,14 +392,17 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
     } catch {
       toast.error("Failed to copy");
     }
-  }, [promptText, promptTextCompressed, wizardData, hasUserInteracted, trackEvent]);
+  }, [promptText, promptTextCompressed, wizardData, hasUserInteracted, isPromptValid]);
 
   const handleTryWithChatGPT = useCallback(() => {
     if (!hasUserInteracted) {
       toast.error("Please interact with the wizard before trying seamlessly");
       return;
     }
-
+    if (!isPromptValid) {
+      toast.error("Please fill in all the required fields");
+      return;
+    }
     const encodedPrompt = encodeURIComponent(promptText);
     // 2000 is a safe limit for most browsers/servers
     if (encodedPrompt.length < 2000) {
@@ -359,13 +418,17 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
         result: "dialog_shown",
       });
     }
-  }, [hasUserInteracted, promptText, wizardData, trackEvent]);
+  }, [hasUserInteracted, promptText, wizardData]);
 
   const handleAnalyzeRequest = useCallback(async () => {
-    // setIsFeatureRequestAlertOpen(true); // Disable feature request dialog for now
     trackEvent("cta_clicked_analyze_with_ai", {
       data: wizardData,
     });
+
+    if (!env.VITE_ENABLE_PROMPT_ANALYSIS) {
+      setIsFeatureRequestAlertOpen(true); // Disable feature request dialog for now
+      return;
+    }
 
     try {
       setPromptAnalysisState("loading");
@@ -388,7 +451,7 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
         toast.error("Failed to analyze prompt. Please try again.");
       }
     }
-  }, [wizardData, trackEvent, analyzePromptFn]);
+  }, [wizardData, analyzePromptFn]);
 
   const confirmFeatureRequest = async () => {
     try {
@@ -404,6 +467,96 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
     }
   };
 
+  // ─────────────────────────────────────────────────────────────────────────────
+  // FEATURE LOCK LOGIC
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  // State
+  const [savedSlug, setSavedSlug] = useState<string | null>(props.shareUrl || null);
+  const [isLockedAlertOpen, setIsLockedAlertOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const savePrompt = useMutation(api.prompts.savePrompt);
+
+  const isLocked = !savedSlug;
+
+  const handleSavePrompt = useCallback(
+    async (silent?: boolean) => {
+      if (!hasUserInteracted) {
+        toast.error("Add some content to your prompt first!");
+        return null;
+      }
+      if (!isPromptValid) {
+        toast.error("Please fill in all the required fields");
+        return null;
+      }
+      try {
+        setIsSaving(true);
+        const sessionId = getOrCreateSessionId();
+        const result = await savePrompt({
+          promptData: wizardData,
+          sessionId,
+        });
+
+        if (result) {
+          setSavedSlug(result.slug);
+          trackEvent("prompt_saved_background", {
+            data: wizardData,
+            slug: result.slug,
+          });
+          if (!silent) {
+            toast.success("Prompt saved!");
+          }
+          return result;
+        }
+      } catch (error) {
+        console.error(error);
+        toast.error("Failed to save prompt");
+      } finally {
+        setIsSaving(false);
+      }
+      return null;
+    },
+    [wizardData, hasUserInteracted, savePrompt, isPromptValid]
+  );
+
+  const handleLockedAction = useCallback(
+    (featureName: string, action: () => void) => {
+      if (isLocked) {
+        trackEvent("feature_locked_click", {
+          feature: featureName,
+        });
+        setIsLockedAlertOpen(true);
+      } else {
+        action();
+      }
+    },
+    [isLocked, trackEvent]
+  );
+
+  // Unsaved changes warning
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      // If locked and has content, warn user
+      if (isLocked && hasUserInteracted) {
+        e.preventDefault();
+        e.returnValue = ""; // Chrome requires returnValue to be set
+      }
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [isLocked, hasUserInteracted]);
+
+  const savePromptDisabled = isSaving || !hasUserInteracted || !isPromptValid;
+  let savedPromptLabel = "Save Prompt";
+  if (isSaving) {
+    savedPromptLabel = "Saving...";
+  } else if (savedSlug) {
+    savedPromptLabel = "Saved";
+  }
+
   return (
     <div className="space-y-8">
       <motion.div
@@ -415,9 +568,31 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
         <div className="p-4 border-b-4 border-foreground flex flex-row gap-3 items-center justify-between">
           <h3 className="font-black uppercase text-lg hidden md:block">Your Prompt</h3>
           <div className="flex flex-row gap-2 overflow-x-auto pb-2 -mb-2 w-full md:w-auto md:pb-0 md:mb-0 no-scrollbar items-center">
+            {/* Added: SAVE BUTTON */}
+            <div className="shrink-0">
+              <Button
+                onClick={() => handleSavePrompt(false)}
+                size="sm"
+                className={cn(
+                  "uppercase font-bold bg-indigo-600 hover:bg-indigo-700 text-white whitespace-nowrap cursor-pointer",
+                  !isLocked && "bg-green-600 hover:bg-green-700" // Visual cue that it's saved
+                )}
+                disabled={savePromptDisabled}
+              >
+                {isSaving ? (
+                  <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+                ) : !isLocked ? (
+                  <Check className="w-4 h-4 mr-1" />
+                ) : (
+                  <Save className="w-4 h-4 mr-1" />
+                )}
+                {savedPromptLabel}
+              </Button>
+            </div>
+
             <div className="flex gap-2 shrink-0">
               <Button
-                onClick={handleCopyPrompt}
+                onClick={() => handleLockedAction("copy", handleCopyPrompt)}
                 size="sm"
                 variant="outline"
                 className="uppercase font-bold whitespace-nowrap cursor-pointer"
@@ -436,13 +611,27 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
                 )}
               </Button>
               <div className="shrink-0">
-                <ShareAction
-                  wizardData={wizardData}
-                  pageSource="wizard"
-                  buttonClassName="w-auto px-4 cursor-pointer"
-                  openLabel="Share"
-                  disabled={promptText.trim().length === 0}
-                />
+                {/* ShareAction needs to be wrapped or handle locked state */}
+                <div
+                  onClickCapture={(e) => {
+                    if (isLocked) {
+                      e.stopPropagation();
+                      handleLockedAction("share", () => {}); // No-op action, just triggers alert
+                    }
+                  }}
+                >
+                  <ShareAction
+                    wizardData={wizardData}
+                    pageSource="wizard"
+                    buttonClassName={cn(
+                      "w-auto px-4 cursor-pointer",
+                      isLocked && "opacity-50 pointer-events-none"
+                    )} // Visual disabled state but captured by parent
+                    openLabel="Share"
+                    disabled={promptText.trim().length === 0}
+                    existingSlug={savedSlug || undefined}
+                  />
+                </div>
               </div>
             </div>
 
@@ -472,7 +661,7 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
                 </span>
               </Button>
               <Button
-                onClick={handleTryWithChatGPT}
+                onClick={() => handleLockedAction("chatgpt", handleTryWithChatGPT)}
                 size="sm"
                 className="uppercase font-bold bg-green-600 hover:bg-green-700 text-white whitespace-nowrap cursor-pointer"
                 disabled={promptText.trim().length === 0}
@@ -488,6 +677,20 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
         <div className="p-4 max-h-[400px] overflow-y-auto">
           <pre className="whitespace-pre-wrap font-mono text-sm leading-relaxed">{promptText}</pre>
         </div>
+
+        {/* Locked Feature Alert Dialog */}
+        <LockedFeatureAlertDialog
+          open={isLockedAlertOpen}
+          onOpenChange={setIsLockedAlertOpen}
+          onSave={async () => {
+            const result = await handleSavePrompt(false);
+            if (result) {
+              setIsLockedAlertOpen(false);
+            }
+          }}
+          isSaving={isSaving}
+        />
+
         {/* ChatGPT Alert Dialog */}
         <AlertDialog open={isChatGPTAlertOpen} onOpenChange={setIsChatGPTAlertOpen}>
           <AlertDialogContent>
@@ -575,6 +778,47 @@ function WizardPreviewForWizardPage(props: WizardPreviewPropsForWizardPage) {
         </motion.div>
       )}
     </div>
+  );
+}
+
+function LockedFeatureAlertDialog({
+  open,
+  onOpenChange,
+  onSave,
+  isSaving,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: () => void;
+  isSaving: boolean;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Save to Unlock Features</AlertDialogTitle>
+          <AlertDialogDescription>
+            Please save your prompt to copy, share, or use it with ChatGPT.
+            <br />
+            <br />
+            This helps you keep track of your best prompts and ensures you don't lose your work.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isSaving}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault(); // Prevent closing immediately
+              onSave();
+            }}
+            disabled={isSaving}
+          >
+            {isSaving ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : null}
+            {isSaving ? "Saving..." : "Save Prompt"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -784,7 +1028,15 @@ function ShareAction({
   // Consider a prompt active if it has at least user interaction
   const hasContent = wizardData.updatedAt > 0;
 
+  // New prop: savedSlug. If passed, we use it directly instead of creating a new one?
+  // Current logic creates a new link if !shareLink.
+  // If we have existingSlug, we use it.
+
   const handleOpenChange = (open: boolean) => {
+    // If disabled (locked), this shouldn't be callable normally, but just in case
+    if (disabled) {
+      return;
+    }
     setIsOpen(open);
     if (open && !shareLink) {
       handleCreateLink();

--- a/src/components/prompt-wizard/WizardProgress.tsx
+++ b/src/components/prompt-wizard/WizardProgress.tsx
@@ -2,7 +2,6 @@ import { motion, AnimatePresence } from "motion/react";
 import { Check } from "lucide-react";
 import { WIZARD_STEPS } from "@/utils/prompt-wizard/schema";
 import { useWizardStore } from "@/stores/wizard-store";
-import { Logger } from "@/utils/logger";
 
 interface WizardProgressProps {
   onStepClick: (step: number) => void;

--- a/src/stores/wizard-store.ts
+++ b/src/stores/wizard-store.ts
@@ -220,7 +220,17 @@ const depthMap: Record<string, string> = {
   thorough: "Provide thorough, in-depth analysis.",
 };
 
-export function generatePromptText(finalData: PromptWizardData): string {
+export function generatePromptText(
+  finalData: PromptWizardData,
+  source:
+    | "WizardPreview"
+    | "AnalysisPanel"
+    | "generatePromptStringFromCompressed"
+    | "PromptWizard"
+    | "WizardNavigation"
+    | "WizardPreviewForWizardPage"
+    | "WizardPreviewForLandingPageV2"
+): string {
   if (finalData.updatedAt === -1) {
     return "";
   }
@@ -245,31 +255,34 @@ export function generatePromptText(finalData: PromptWizardData): string {
     sections.push(`## Examples\n${finalData.examples}`);
   }
 
-  // 4. Guardrails (How NOT to do it)
-  if (finalData.constraints) {
-    sections.push(`## Constraints\n${finalData.constraints}`);
-  }
+  const wizardMode = useWizardStore.getState().wizardMode;
+  if (source === "WizardPreviewForLandingPageV2" || wizardMode === "advanced") {
+    // 4. Guardrails (How NOT to do it)
+    if (finalData.constraints) {
+      sections.push(`## Constraints\n${finalData.constraints}`);
+    }
 
-  if (finalData.disallowed_content) {
-    sections.push(`## Avoid\n${finalData.disallowed_content}`);
-  }
+    if (finalData.disallowed_content) {
+      sections.push(`## Avoid\n${finalData.disallowed_content}`);
+    }
 
-  // 5. Format (How to present it)
-  if (finalData.output_format) {
-    sections.push(
-      `## Output Format\n${formatMap[finalData.output_format] || finalData.output_format}`
-    );
-  }
+    // 5. Format (How to present it)
+    if (finalData.output_format) {
+      sections.push(
+        `## Output Format\n${formatMap[finalData.output_format] || finalData.output_format}`
+      );
+    }
 
-  // 6. Refinements (Optional extras)
-  if (finalData.reasoning_depth && finalData.reasoning_depth !== "brief") {
-    sections.push(`## Reasoning\n${depthMap[finalData.reasoning_depth]}`);
-  }
+    // 6. Refinements (Optional extras)
+    if (finalData.reasoning_depth && finalData.reasoning_depth !== "brief") {
+      sections.push(`## Reasoning\n${depthMap[finalData.reasoning_depth]}`);
+    }
 
-  if (finalData.self_check) {
-    sections.push(
-      `## Self-Check\nBefore finalizing, verify your response is accurate and complete.`
-    );
+    if (finalData.self_check) {
+      sections.push(
+        `## Self-Check\nBefore finalizing, verify your response is accurate and complete.`
+      );
+    }
   }
 
   return sections.join("\n\n");

--- a/src/utils/analytics/MixpanelProvider.tsx
+++ b/src/utils/analytics/MixpanelProvider.tsx
@@ -85,6 +85,8 @@ const MixpanelDataSchema = z.object({
     "prompt_analyzed_error",
     "prompt_analyzed_cache_hit",
     "cta_clicked_analyze_with_ai",
+    "feature_locked_click",
+    "prompt_saved_background",
   ]),
   properties: z.looseObject({
     distinct_id: z.string(),

--- a/src/utils/client/env.ts
+++ b/src/utils/client/env.ts
@@ -12,6 +12,7 @@ export const env = createEnv({
     VITE_APP_TITLE: z.string().min(1).optional(),
     VITE_PUBLIC_MIXPANEL_PROJECT_TOKEN: z.string(),
     VITE_CONVEX_URL: z.string(),
+    VITE_ENABLE_PROMPT_ANALYSIS: z.enum(["true", "false"]).optional().default("false"),
   },
 
   /**

--- a/src/utils/server/env.ts
+++ b/src/utils/server/env.ts
@@ -6,7 +6,7 @@ export const env = createEnv({
     SERVER_URL: z.url().optional(),
     SENTRY_AUTH_TOKEN: z.string(),
     GOOGLE_GENERATIVE_AI_API_KEY: z.string().optional(),
-    ENABLE_PROMPT_ANALYSIS: z.enum(["true", "false"]).optional(),
+    ENABLE_PROMPT_ANALYSIS: z.enum(["true", "false"]).optional().default("false"),
   },
 
   /**


### PR DESCRIPTION
This PR introduces the "Save-to-Unlock" pattern, ensuring key features like Copy, Share, and ChatGPT integration are locked until the prompt is saved. It also consolidates the save logic into the value of truth components.

Key Changes:

Lifted save state and mutation logic to PromptWizard for a single source of truth.
Implemented LockedFeatureAlertDialog to guide users to save before accessing advanced features.
Removed internal save buttons from WizardPreview, relying on the main navigation "Save Prompt" button.
Defaulted reloadDocument on critical navigation links to ensure a fresh state.
Standardized sessionId usage and implemented robust error handling for the save flow.
Added stricter prompt generation logic to respect wizardMode (eliminating ghost data from advanced steps).
Resolved TypeScript errors and cleaned up unused navigation props.
Added feature_locked_click and prompt_saved_background analytics events.